### PR TITLE
fix 'Find number of lines shared by 2 files' oneliner - without 'wc -…

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Count the number of unique lines in file.txt
 
 Find number of lines shared by 2 files (assumes lines within file1 and file2 are unique):
 
-    sort file1 file2 | uniq -d
+    sort file1 file2 | uniq -d | wc -l
 
 
 Sort numerically (with logs) (g) by column (k) 9:


### PR DESCRIPTION
…l' it outputs the actual lines, not the number