### PR TITLE
added one-liner find & xargs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,21 @@ Delete all .bam files (Irreversible: use with caution! Confirm list BEFORE delet
     find . -name "*.bam" | xargs rm
 
 
+Find the largest file in a directory:
+
+    find . -type f -printf '%s %p\n' | sort -nr | head -1 | cut -d' ' -f2-
+
+
+Count the number of lines in all files with a specific extension in a directory
+
+    find . -type f -name '*.txt' -exec wc -l {} \; | awk '{total += $1} END {print total}'
+
+
+Find all directories in the current directory that contain files with the extension ".log" and compress them into a tar archive:
+
+    find . -type f -name "*.log" -printf "%h\0" | sort -uz | xargs -0 tar -czvf logs.tar.gz
+
+
 Rename all .txt files to .bak (backup *.txt before doing something else to them, for example):
 
     find . -name "*.txt" | sed "s/\.txt$//" | xargs -i echo mv {}.txt {}.bak | sh


### PR DESCRIPTION
# Hi there 👋
## I've added three one-liner bash commands (`find` & `xargs`)😉

👨‍💻 I have used the `ls` command instead of the `-printf` option in the first command to display the size and filename in a human-readable format. 

👨‍💻 In the second command, I have used `paste` and `bc` commands to sum up the line counts from all files. 

👨‍💻 In the third command, I have used `dirname` command to extract the directory name from the matched files and then used `sort` and `uniq` commands to remove duplicates before passing them to `tar` command. 🚀